### PR TITLE
[Fix] ヘッダーとフッタとフラッシュメッセージ修正

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,7 +1,9 @@
-<footer class="fixed-bottom border-top">
+<div style="padding-top: 70px;">
+  <footer class="fixed-bottom border-top bg-white">
   <div class="container">
     <div class="row py-3">
       <h5 class="mx-auto">ながのCAKE</h5>
     </div>
   </div>
 </footer>
+</div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,4 +1,4 @@
-<header class="shadow-sm">
+<header class="sticky-top bg-white shadow-sm">
   <nav class="navbar navbar-expand-lg navbar-light">
     <div class="container">
       <a class="navbar-brand" href="/"><span>ながのCAKE</span></a>

--- a/app/views/public/items/show.html.erb
+++ b/app/views/public/items/show.html.erb
@@ -11,7 +11,6 @@
       <h4><%= @item.introduction %></h4>
       <h3>¥<%= @item.price_add_tax.to_s(:delimited) %>（税込）</h3>
       <div class="mt-5">
-        <%= flash[:notice] %>
         <% if @item.is_active == true %>
           <%= form_with model: @cart_item,url: cart_items_path, local: true do |f| %>
           <%= f.hidden_field :item_id, :value => @item.id %>


### PR DESCRIPTION
軽微な修正を加えたプルリクです！

・ヘッダー→スクロールしても上部に固定表示されるようにしました。スクロールした時、ヘッダー以外の要素が透けてしまっていたので背景色（白）を追加しました。

・フッター→要素が多いページの場合、フッター以外の要素が重なってしまったのでフッター全体をdivタグで囲み、要素が重ならないようにしました（だいぶ無理矢理ですが…）。ヘッダー同様、背景色（白）を追加しています。

・フラッシュメッセージ→商品詳細画面で、個数選択せずにカートに入れようとした際2箇所にフラッシュメッセージが出ていたので、ひとつ削除しました。